### PR TITLE
社員情報登録画面でメールアドレス、入社日、お知らせ投稿権限を入力できるようにする

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -15,8 +15,6 @@ class EmployeesController < ApplicationController
   def create
     @employee = Employee.new(employee_params)
 
-    add_params
-
     if @employee.save
       redirect_to employees_url, notice: "社員「#{@employee.last_name} #{@employee.first_name}」を登録しました。"
     else
@@ -27,8 +25,6 @@ class EmployeesController < ApplicationController
   def edit; end
 
   def update
-    add_params
-
     if @employee.update(employee_params)
       redirect_to employees_url, notice: "社員「#{@employee.last_name} #{@employee.first_name}」を更新しました。"
     else
@@ -49,7 +45,8 @@ class EmployeesController < ApplicationController
   private
 
   def employee_params
-    params.require(:employee).permit(:number, :last_name, :first_name, :account, :password, :department_id, :office_id, :employee_info_manage_auth)
+    params.require(:employee).permit(:number, :last_name, :first_name, :account, :password, :department_id, :office_id, :employee_info_manage_auth, :email,
+                                     :date_of_joining, :news_posting_auth)
   end
 
   def set_employee
@@ -59,12 +56,6 @@ class EmployeesController < ApplicationController
   def set_form_option
     @departments = Department.all
     @offices = Office.all
-  end
-
-  # 現在、メールアドレスと入社日は入力できないため、ここで追加しています。
-  def add_params
-    @employee.email = 'sample@example.com' unless @employee.email
-    @employee.date_of_joining = Time.zone.today unless @employee.date_of_joining
   end
 
   def sort_column

--- a/app/views/employees/_form.html.slim
+++ b/app/views/employees/_form.html.slim
@@ -20,6 +20,12 @@
       = f.label :password
       = f.password_field :password
     .form_group
+      = f.label :e_mail
+      = f.text_field :email
+    .form_group
+      = f.label :date_of_joining
+      = f.text_field :date_of_joining
+    .form_group
       = f.label :department_id
       = f.collection_select(:department_id, @departments, :id, :name)
     .form_group
@@ -28,4 +34,7 @@
     .form_group
       = f.label :employee_info_manage_auth, class: 'checkbox_label'
       = f.check_box :employee_info_manage_auth, { as: :boolean }
+    .form_group
+      = f.label :news_posting_auth, class: 'checkbox_label'
+      = f.check_box :news_posting_auth, { as: :boolean }
     = f.submit '保存'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -33,5 +33,6 @@ ja:
         department_id: 部署
         office_id: オフィス
         employee_info_manage_auth: 社員情報管理権限
+        news_posting_auth: お知らせ投稿権限
       profile:
         profile: プロフィール

--- a/db/migrate/20221019083652_add_news_posting_auth_to_employees.rb
+++ b/db/migrate/20221019083652_add_news_posting_auth_to_employees.rb
@@ -1,0 +1,5 @@
+class AddNewsPostingAuthToEmployees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :employees, :news_posting_auth, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_20_112406) do
+ActiveRecord::Schema.define(version: 2022_10_19_083652) do
 
   create_table "departments", force: :cascade do |t|
     t.string "name", null: false
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2021_10_20_112406) do
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "news_posting_auth", default: false, null: false
     t.index ["department_id"], name: "index_employees_on_department_id"
     t.index ["office_id"], name: "index_employees_on_office_id"
   end

--- a/spec/system/employees_spec.rb
+++ b/spec/system/employees_spec.rb
@@ -50,6 +50,23 @@ describe 'Employees', js: true, type: :system do
         expect(page).to have_content '技術部'
         expect(page).to have_content '大阪'
       end
+
+      it 'create employee' do
+        click_link '新規追加'
+        fill_in 'employee_number', with: 3
+        fill_in 'employee_last_name', with: '治'
+        fill_in 'employee_first_name', with: '太宰'
+        fill_in 'employee_account', with: 'account'
+        fill_in 'employee_password', with: 'hogehoge'
+        fill_in 'employee_email', with: 'hoge@example.com'
+        check 'お知らせ投稿権限'
+        check '社員情報管理権限'
+        fill_in 'employee_date_of_joining', with: '2022-04-01'
+        select '技術部', from: 'employee_department_id'
+        select '大阪', from: 'employee_office_id'
+        click_on '保存'
+        expect(page).to have_content '治 太宰'
+      end
     end
 
     context 'when employee is logged in' do


### PR DESCRIPTION
## 目的
社員情報登録画面でメールアドレス、入社日、お知らせ投稿権限を入力できるようにする
## 実施したこと
- お知らせ投稿権限のカラムを追加
- メールアドレス、入社日、お知らせ投稿権限をparamsに追加
- 社員情報登録画面でメールアドレス、入社日、お知らせ投稿権限の項目を表示
## UI before/after

### before
<img width="536" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/196696826-c5649acc-6575-4b2d-8869-09efe00c93d4.png">

### after
<img width="522" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/196697445-8d33aad2-07cf-4be1-b59b-dd48eed75d2b.png">
