### PR TITLE
お知らせ機能を実装する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,4 +63,5 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'bootstrap', '~> 5.2', '>= 5.2.1'
 gem 'html2slim', '~> 0.2.0'
+gem 'ransack'
 gem 'slim-rails', '~> 3.5', '>= 3.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,10 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
+    ransack (3.1.0)
+      activerecord (>= 6.0.4)
+      activesupport (>= 6.0.4)
+      i18n
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -295,6 +299,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4, >= 6.1.4.1)
+  ransack
   rspec-rails (~> 6.0)
   rubocop
   rubocop-fjord (~> 0.2.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -109,3 +109,19 @@ tr {
   border: 0;
 }
 
+.article {
+  width: 80%;
+}
+
+.form-group .new-article-form {
+  width: 100%;
+}
+
+.text-area-size {
+  height: 16rem;
+}
+
+
+.alert.alert-success {
+  height: 3.2rem;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -125,3 +125,7 @@ tr {
 .alert.alert-success {
   height: 3.2rem;
 }
+
+ul.error-message {
+  list-style-type: none;
+}

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ArticlesController < ApplicationController
+end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -5,7 +5,8 @@ class ArticlesController < ApplicationController
   before_action :set_form_option, only: %i[new create]
 
   def index
-    @articles = Article.active.order(created_at: 'DESC')
+    @q = Article.all.ransack(params[:q])
+    @articles = @q.result(distinct: true)
   end
 
   def new

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -4,4 +4,8 @@ class ArticlesController < ApplicationController
   def index
     @articles = Article.all.order(created_at: 'DESC')
   end
+
+  def show
+    @article = Article.find(params[:id])
+  end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -15,7 +15,7 @@ class ArticlesController < ApplicationController
   def create
     @article = current_user.articles.build(article_params)
     if @article.save
-      redirect_to articles_url, notice: "#{@article.title}を作成しました。"
+      redirect_to articles_url, notice: "「#{@article.title}」を作成しました。"
     else
       render :new
     end
@@ -27,7 +27,7 @@ class ArticlesController < ApplicationController
 
   def update
     if @article.update(article_params)
-      redirect_to articles_url, notice: "#{@article.title}を更新しました。"
+      redirect_to articles_url, notice: "「#{@article.title}」を更新しました。"
     else
       render :edit
     end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class ArticlesController < ApplicationController
+  def index
+    @articles = Article.all.order(created_at: 'DESC')
+  end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -5,7 +5,7 @@ class ArticlesController < ApplicationController
   before_action :set_form_option, only: %i[new create]
 
   def index
-    @q = Article.all.ransack(params[:q])
+    @q = Article.all.active.ransack(params[:q])
     @articles = @q.result(distinct: true)
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,11 +1,49 @@
 # frozen_string_literal: true
 
 class ArticlesController < ApplicationController
+  before_action :set_article, only: %i[edit show update]
+  before_action :set_form_option, only: %i[new create]
+
   def index
     @articles = Article.all.order(created_at: 'DESC')
   end
 
-  def show
+  def new
+    @article = Article.new
+  end
+
+  def create
+    @article = current_user.articles.build(article_params)
+    if @article.save
+      redirect_to articles_url, notice: "#{@article.title}を作成しました。"
+    else
+      render :new
+    end
+  end
+
+  def show; end
+
+  def edit; end
+
+  def update
+    if @article.update(article_params)
+      redirect_to articles_url, notice: "#{@article.title}を更新しました。"
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def article_params
+    params.require(:article).permit(:title, :content, :employee)
+  end
+
+  def set_article
     @article = Article.find(params[:id])
+  end
+
+  def set_form_option
+    @employee = Employee.find(current_user.id)
   end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class ArticlesController < ApplicationController
-  before_action :set_article, only: %i[edit show update]
+  before_action :set_article, only: %i[edit show update destroy]
   before_action :set_form_option, only: %i[new create]
 
   def index
-    @articles = Article.all.order(created_at: 'DESC')
+    @articles = Article.active.order(created_at: 'DESC')
   end
 
   def new
@@ -31,6 +31,15 @@ class ArticlesController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    ActiveRecord::Base.transaction do
+      now = Time.zone.now
+      @article.update(deleted_at: now)
+    end
+
+    redirect_to articles_url, notice: "「#{@article.title}」を削除しました。"
   end
 
   private

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -6,6 +6,7 @@ class Article < ApplicationRecord
   validates :title, presence: true, length: { maximum: 50 }
   validates :content, presence: true
 
+  scope :recent, -> { order(created_at: :desc) }
   scope :active, lambda {
     where(deleted_at: nil)
   }

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Article < ApplicationRecord
+  belongs_to :employee
+
+  validates :title, presence: true, length: { maximum: 50 }
+  validates :content, presence: true
+
+  scope :active, lambda {
+    where(deleted_at: nil)
+  }
+end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -5,6 +5,7 @@ class Employee < ApplicationRecord
   belongs_to :office
   belongs_to :department
   has_many :profiles, dependent: :destroy
+  has_many :articles, dependent: :destroy
 
   validates :number, presence: true, uniqueness: true
   validates :last_name, presence: true

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -1,6 +1,6 @@
 .article
   .nav.justify-content-end.mt-3
-    = link_to 'お知らせ一覧', articles_path, class: 'btn btn-primary'
+    = link_to '一覧に戻る', articles_path, class: 'btn btn-primary'
   - if article.errors.present?
     ul.error-message.text-danger.ps-0
       - article.errors.full_messages.each do |message|
@@ -10,7 +10,6 @@
       = f.label :title
       = f.text_field :title, class: 'form-control mt-1 new-article-form'
     .form-group
-      = f.label :content
       = f.text_area :content, class: 'form-control mt-1 new-article-form text-area-size'
     .nav.justify-content-end
       = f.submit nil, class: 'btn btn-secondary'

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -1,10 +1,12 @@
-.nav.justify-content-end
-  = link_to 'お知らせ一覧', articles_path, class: 'btn'
-
-= form_with model: @article, local: true do |f|
-  .form-group
-    = f.label :title
-    = f.text_field :title
-  .form-group
-    = f.text_field :content
-  = f.submit nil, class: 'btn'
+.article
+  .nav.justify-content-end.mt-3
+    = link_to 'お知らせ一覧', articles_path, class: 'btn btn-primary'
+  = form_with model: @article, local: true do |f|
+    .form-group
+      = f.label :title
+      = f.text_field :title, class: 'form-control mt-1 new-article-form'
+    .form-group
+      = f.label :content
+      = f.text_area :content, class: 'form-control mt-1 new-article-form text-area-size'
+    .nav.justify-content-end
+      = f.submit nil, class: 'btn btn-secondary'

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -1,0 +1,10 @@
+.nav.justify-content-end
+  = link_to 'お知らせ一覧', articles_path, class: 'btn'
+
+= form_with model: @article, local: true do |f|
+  .form-group
+    = f.label :title
+    = f.text_field :title
+  .form-group
+    = f.text_field :content
+  = f.submit nil, class: 'btn'

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -1,6 +1,10 @@
 .article
   .nav.justify-content-end.mt-3
     = link_to 'お知らせ一覧', articles_path, class: 'btn btn-primary'
+  - if article.errors.present?
+    ul.error-message.text-danger.ps-0
+      - article.errors.full_messages.each do |message|
+        li.alert-success = message
   = form_with model: @article, local: true do |f|
     .form-group
       = f.label :title

--- a/app/views/articles/edit.html.slim
+++ b/app/views/articles/edit.html.slim
@@ -1,0 +1,1 @@
+= render partial: 'form', locals: { article: @article }

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -1,14 +1,18 @@
 .article.mt-3
+  = search_form_for @q, class: 'mb-3' do |f|
+    .form-group.row
+      = f.label :title_cont, 'タイトルで検索する', class: 'col-sm-3 col-form-label'
+      .col-sm-10
+        = f.search_field :title_cont, class: 'form-control'
+        = f.submit class: 'btn btn-outline-primary mt-2'
   - if current_user.news_posting_auth
     .nav.justify-content-end
       = link_to '新規追加', new_article_path, class: 'btn btn-primary'
   table.table.mt-3
     thead
       tr
-        th
-          | タイトル
-        th
-          | 公開日
+        th = Article.human_attribute_name(:title)
+        th = sort_link(@q, :created_at, default_order: :asc)
       tbody
         - @articles.each do |article|
           tr.article

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -1,24 +1,22 @@
-.article_index
-  - if flash.notice.present?
-    p
-      = flash.notice
+.article.mt-3
   - if current_user.news_posting_auth
-    p.new_article
-      = link_to '新規追加', new_article_path, class: 'btn'
-  table.table.table-hover
-   thead
-    tr
-      th
-        | タイトル
-      th
-        | 公開日
-    tbody
-      - @articles.each do |article|
-        tr.article
-          td = link_to article.title, article_path(article)
-          td = article.created_at.strftime('%Y/%m/%d')
-          - if current_user.news_posting_auth && article.employee_id == current_user.id
-            td
-              = link_to '編集', edit_article_path(article), class: 'btn'
-            td
-              = link_to '削除', article, method: :delete, data: { confirm: "#{article.title}を削除しますか？" }, class: 'btn'
+    .nav.justify-content-end
+      = link_to '新規追加', new_article_path, class: 'btn btn-primary'
+  table.table.mt-3
+    thead
+      tr
+        th
+          | タイトル
+        th
+          | 公開日
+      tbody
+        - @articles.each do |article|
+          tr.article
+            td = link_to article.title, article_path(article)
+            td = article.created_at.strftime('%Y/%m/%d')
+            - if current_user.news_posting_auth && article.employee_id == current_user.id
+              td
+                = link_to '編集', edit_article_path(article), class: 'btn btn-secondary'
+              td
+                = link_to '削除', article, method: :delete, data: { confirm: "「#{article.title}」を削除しますか？" },
+                class: 'btn btn-danger'

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -1,7 +1,10 @@
 .article_index
+  - if flash.notice.present?
+    p
+      = flash.notice
   - if current_user.news_posting_auth
     p.new_article
-      = link_to '新規追加', new_employee_path, class: 'btn'
+      = link_to '新規追加', new_article_path, class: 'btn'
   table.table.table-hover
    thead
     tr
@@ -18,4 +21,4 @@
             td
               = link_to '編集', edit_article_path(article), class: 'btn'
             td
-              = link_to '削除', article, method: :delete, data: { confirm: "#{article.title}}」を削除します。よろしいですか？" }, class: 'btn'
+              = link_to '削除', article, method: :delete, data: { confirm: "#{article.title}を削除しますか？" }, class: 'btn'

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -1,4 +1,7 @@
 .article.mt-3
+  - if flash.notice.present?
+    .alert.alert-success.mt-1
+      = flash.notice
   = search_form_for @q, class: 'mb-3' do |f|
     .form-group.row
       = f.label :title_cont, 'タイトルで検索する', class: 'col-sm-3 col-form-label'

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -1,0 +1,21 @@
+.article_index
+  - if current_user.news_posting_auth
+    p.new_article
+      = link_to '新規追加', new_employee_path, class: 'btn'
+  table.table.table-hover
+   thead
+    tr
+      th
+        | タイトル
+      th
+        | 公開日
+    tbody
+      - @articles.each do |article|
+        tr.article
+          td = link_to article.title, article_path(article)
+          td = article.created_at.strftime('%Y/%m/%d')
+          - if current_user.news_posting_auth && article.employee_id == current_user.id
+            td
+              = link_to '編集', edit_article_path(article), class: 'btn'
+            td
+              = link_to '削除', article, method: :delete, data: { confirm: "#{article.title}}」を削除します。よろしいですか？" }, class: 'btn'

--- a/app/views/articles/new.html.slim
+++ b/app/views/articles/new.html.slim
@@ -1,0 +1,1 @@
+= render partial: 'form', locals: { article: @article }

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -1,14 +1,12 @@
 .article
   .nav.justify-content-end.mt-3
-    = link_to 'お知らせ一覧に戻る', articles_path, class: 'btn btn-primary'
+    = link_to '一覧に戻る', articles_path, class: 'btn btn-primary'
   .mt-3
     .form-label.justify-content-start
       | タイトル
     .form-control
       = @article.title
-    .form-label.justify-content-start.mt-3
-      | お知らせ
-    .form-control.text-area-size
+    .form-control.text-area-size.mt-2
       = simple_format(h(@article.content), {}, sanitize: false, wrapper_tag: 'div')
   - if current_user.news_posting_auth && @article.employee_id == current_user.id
     .nav.justify-content-end.mt-3

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -1,13 +1,17 @@
-.article_show
-  .nav.justify-content-end
-    = link_to 'お知らせ一覧', articles_path, class: 'btn'
-  p.title
-    = "タイトル #{@article.title}"
-  .card
-    .card-body
-      = @article.content
+.article
+  .nav.justify-content-end.mt-3
+    = link_to 'お知らせ一覧に戻る', articles_path, class: 'btn btn-primary'
+  .mt-3
+    .form-label.justify-content-start
+      | タイトル
+    .form-control
+      = @article.title
+    .form-label.justify-content-start.mt-3
+      | お知らせ
+    .form-control.text-area-size
+      = simple_format(h(@article.content), {}, sanitize: false, wrapper_tag: 'div')
   - if current_user.news_posting_auth && @article.employee_id == current_user.id
-    .nav.justify-content
-      = link_to '編集', edit_article_path, class: 'btn'
-    .nav.justify-content
-      = link_to '削除', @article, method: :delete, data: { confirm: "#{@article.title}}」を削除します。よろしいですか？" }, class: 'btn'
+    .nav.justify-content-end.mt-3
+      = link_to '編集', edit_article_path, class: 'btn btn-secondary'
+      = link_to '削除', @article, method: :delete, data: { confirm: "#{@article.title}}」を削除します。よろしいですか？" },
+      class: 'btn btn-danger ms-2'

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -1,0 +1,13 @@
+.article_show
+  .nav.justify-content-end
+    = link_to 'お知らせ一覧', articles_path, class: 'btn'
+  p.title
+    = "タイトル #{@article.title}"
+  .card
+    .card-body
+      = @article.content
+  - if current_user.news_posting_auth && @article.employee_id == current_user.id
+    .nav.justify-content
+      = link_to '編集', edit_article_path, class: 'btn'
+    .nav.justify-content
+      = link_to '削除', @article, method: :delete, data: { confirm: "#{@article.title}}」を削除します。よろしいですか？" }, class: 'btn'

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -2,7 +2,7 @@
 #menu
   ul.left_menu
     li
-      = link_to 'お知らせ', '#'
+      = link_to 'お知らせ', articles_path
     li
       = link_to '社員紹介', employees_path
   ul.right_menu

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -12,4 +12,7 @@ html
     - if logged_in?
       = render 'layouts/header'
     .container
+      - if flash.notice.present?
+        .alert.alert-success.mt-1
+          = flash.notice
       = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -12,7 +12,4 @@ html
     - if logged_in?
       = render 'layouts/header'
     .container
-      - if flash.notice.present?
-        .alert.alert-success.mt-1
-          = flash.notice
       = yield

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -43,3 +43,4 @@ ja:
       article:
         title: タイトル
         content: お知らせ
+        created_at: 公開日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,8 @@
 ja:
+  helpers:
+    submit:
+      update: 更新
+      create: 作成
   activerecord:
     errors:
       messages:
@@ -36,3 +40,5 @@ ja:
         news_posting_auth: お知らせ投稿権限
       profile:
         profile: プロフィール
+      article:
+        title: タイトル

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,7 +2,7 @@ ja:
   helpers:
     submit:
       update: 更新
-      create: 作成
+      create: 保存
   activerecord:
     errors:
       messages:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -42,3 +42,4 @@ ja:
         profile: プロフィール
       article:
         title: タイトル
+        content: お知らせ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :articles
   resources :dashboard, only: :index
   root 'employees#index'
 

--- a/db/migrate/20221020111932_create_articles.rb
+++ b/db/migrate/20221020111932_create_articles.rb
@@ -1,0 +1,13 @@
+class CreateArticles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :articles do |t|
+      t.string :title, null: false
+      t.text :content, null: false
+      t.references :employee, null: false, foreign_key: true
+      t.datetime :deleted_at, null: true, default: nil
+
+      t.timestamps
+    end
+    add_foreign_key :articles, :employees
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_19_083652) do
+ActiveRecord::Schema.define(version: 2022_10_20_111932) do
+
+  create_table "articles", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "content", null: false
+    t.integer "employee_id", null: false
+    t.datetime "deleted_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["employee_id"], name: "index_articles_on_employee_id"
+  end
 
   create_table "departments", force: :cascade do |t|
     t.string "name", null: false
@@ -54,6 +64,8 @@ ActiveRecord::Schema.define(version: 2022_10_19_083652) do
     t.index ["employee_id"], name: "index_profiles_on_employee_id"
   end
 
+  add_foreign_key "articles", "employees"
+  add_foreign_key "articles", "employees"
   add_foreign_key "employees", "departments"
   add_foreign_key "employees", "offices"
   add_foreign_key "profiles", "employees"

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :article do
     title { 'MyString' }
     content { 'MyText' }
-    employee
+    created_at { '2022/10/01' }
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :article do
+    title { 'MyString' }
+    content { 'MyText' }
+    employee
+  end
+end

--- a/spec/factories/employees.rb
+++ b/spec/factories/employees.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     email { 'haruki@example.com' }
     date_of_joining { '1991/4/1' }
     employee_info_manage_auth { 'true' }
+    news_posting_auth { 'true' }
   end
 
   factory :normal_employee, class: 'Employee' do
@@ -25,5 +26,6 @@ FactoryBot.define do
     email { 'sohseki@example.com' }
     date_of_joining { '1991/4/1' }
     employee_info_manage_auth { 'false' }
+    news_posting_auth { 'false' }
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Article, type: :model do
+  let(:employee) { FactoryBot.create(:manager_employee) }
+
+  it 'is valid with a id and title, content, employee id' do
+    article = described_class.new(
+      id: 1,
+      title: 'Hello',
+      content: 'Hello World',
+      employee_id: employee.id
+    )
+    expect(article).to be_valid
+  end
+
+  it 'is invalid without a title' do
+    article = described_class.new(title: nil)
+    article.valid?
+    expect(article.errors[:title]).to include('を入力してください')
+  end
+
+  it 'is invalid title length' do
+    article = described_class.new(
+      id: 1,
+      title: '111111111122222222223333333333444444444455555555556',
+      content: 'Hello World',
+      employee_id: employee.id
+    )
+    article.valid?
+    expect(article.errors[:title]).to include('は50文字以内で入力してください')
+  end
+
+  it 'is invalid without a content' do
+    article = described_class.new(content: nil)
+    article.valid?
+    expect(article.errors[:content]).to include('を入力してください')
+  end
+
+  it 'is invalid without a employee' do
+    article = described_class.new(employee_id: nil)
+    article.valid?
+    expect(article.errors[:employee]).to include('を入力してください')
+  end
+end

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Articles', js: true, type: :system do
+  describe 'article index' do
+    let(:manager_employee) { FactoryBot.create(:manager_employee) }
+    let(:normal_employee) { FactoryBot.create(:normal_employee) }
+
+    before do
+      FactoryBot.create(:department_gizyutu)
+      FactoryBot.create(:office_osaka)
+      FactoryBot.create(:article, employee: manager_employee)
+      visit login_path
+      fill_in 'employees_account', with: login_employee.account
+      fill_in 'employees_password', with: login_employee.password
+      click_button 'ログイン'
+    end
+
+    context 'when authorized employee is logged in' do
+      let(:login_employee) { manager_employee }
+
+      it 'article index appear' do
+        click_link 'お知らせ'
+        expect(page).to have_content 'MyString'
+        expect(page).to have_content '2022/10/01'
+        expect(page).to have_content '編集'
+        expect(page).to have_content '削除'
+        click_link 'MyString'
+        expect(page).to have_content 'MyText'
+        expect(page).to have_content '編集'
+        expect(page).to have_content '削除'
+      end
+    end
+
+    context 'when normal employee is logged in' do
+      let(:login_employee) { normal_employee }
+
+      it 'article index appear' do
+        click_link 'お知らせ'
+        expect(page).to have_content 'MyString'
+        expect(page).to have_content '2022/10/01'
+        expect(page).to_not have_content '編集'
+        expect(page).to_not have_content '削除'
+        click_link 'MyString'
+        expect(page).to have_content 'MyText'
+        expect(page).to_not have_content '編集'
+        expect(page).to_not have_content '削除'
+      end
+    end
+  end
+end

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -38,7 +38,7 @@ describe 'Articles', js: true, type: :system do
         fill_in 'article_title', with: 'MyTitle'
         fill_in 'article_content', with: 'MyContent'
         click_button '更新'
-        expect(page).to have_content 'MyTitleを更新しました。'
+        expect(page).to have_content '「MyTitle」を更新しました。'
       end
 
       it 'create article' do
@@ -47,7 +47,7 @@ describe 'Articles', js: true, type: :system do
         fill_in 'article_title', with: 'MyNumber'
         fill_in 'article_content', with: 'MyNumberを提出してください'
         click_button '作成'
-        expect(page).to have_content 'MyNumberを作成しました。'
+        expect(page).to have_content '「MyNumber」を作成しました。'
       end
 
       it 'delete article' do

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -31,6 +31,24 @@ describe 'Articles', js: true, type: :system do
         expect(page).to have_content '編集'
         expect(page).to have_content '削除'
       end
+
+      it 'edit article' do
+        click_link 'お知らせ'
+        click_link '編集'
+        fill_in 'article_title', with: 'MyTitle'
+        fill_in 'article_content', with: 'MyContent'
+        click_button '更新'
+        expect(page).to have_content 'MyTitleを更新しました。'
+      end
+
+      it 'create article' do
+        click_link 'お知らせ'
+        click_link '新規追加'
+        fill_in 'article_title', with: 'MyNumber'
+        fill_in 'article_content', with: 'MyNumberを提出してください'
+        click_button '作成'
+        expect(page).to have_content 'MyNumberを作成しました。'
+      end
     end
 
     context 'when normal employee is logged in' do
@@ -40,12 +58,12 @@ describe 'Articles', js: true, type: :system do
         click_link 'お知らせ'
         expect(page).to have_content 'MyString'
         expect(page).to have_content '2022/10/01'
-        expect(page).to_not have_content '編集'
-        expect(page).to_not have_content '削除'
+        expect(page).not_to have_content '編集'
+        expect(page).not_to have_content '削除'
         click_link 'MyString'
         expect(page).to have_content 'MyText'
-        expect(page).to_not have_content '編集'
-        expect(page).to_not have_content '削除'
+        expect(page).not_to have_content '編集'
+        expect(page).not_to have_content '削除'
       end
     end
   end

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -11,6 +11,7 @@ describe 'Articles', js: true, type: :system do
       FactoryBot.create(:department_gizyutu)
       FactoryBot.create(:office_osaka)
       FactoryBot.create(:article, employee: manager_employee)
+      FactoryBot.create(:article, title: '検索機能', created_at: '2022/10/31', employee: manager_employee)
       visit login_path
       fill_in 'employees_account', with: login_employee.account
       fill_in 'employees_password', with: login_employee.password
@@ -87,6 +88,22 @@ describe 'Articles', js: true, type: :system do
         expect(page).to have_content 'MyText'
         expect(page).not_to have_content '編集'
         expect(page).not_to have_content '削除'
+      end
+
+      it 'search article' do
+        click_link 'お知らせ'
+        fill_in 'q_title_cont', with: '検索機能'
+        click_button '検索'
+        expect(page).not_to have_content 'MyString'
+        expect(page).to have_content '検索機能'
+      end
+
+      it 'sort created_at article' do
+        click_link 'お知らせ'
+        expect(all('tbody tr')[0]).to have_content '2022/10/01'
+        click_link '公開日'
+        click_link '公開日'
+        expect(all('tbody tr')[1]).to have_content '2022/10/01'
       end
     end
   end

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -11,7 +11,6 @@ describe 'Articles', js: true, type: :system do
       FactoryBot.create(:department_gizyutu)
       FactoryBot.create(:office_osaka)
       FactoryBot.create(:article, employee: manager_employee)
-      FactoryBot.create(:article, title: '検索機能', created_at: '2022/10/31', employee: manager_employee)
       visit login_path
       fill_in 'employees_account', with: login_employee.account
       fill_in 'employees_password', with: login_employee.password
@@ -47,7 +46,7 @@ describe 'Articles', js: true, type: :system do
         click_link '新規追加'
         fill_in 'article_title', with: 'MyNumber'
         fill_in 'article_content', with: 'MyNumberを提出してください'
-        click_button '作成'
+        click_button '保存'
         expect(page).to have_content '「MyNumber」を作成しました。'
       end
 
@@ -55,7 +54,7 @@ describe 'Articles', js: true, type: :system do
         click_link 'お知らせ'
         click_link '新規追加'
         fill_in 'article_title', with: ''
-        click_button '作成'
+        click_button '保存'
         expect(page).to have_content 'タイトル を入力してください'
       end
 
@@ -63,7 +62,7 @@ describe 'Articles', js: true, type: :system do
         click_link 'お知らせ'
         click_link '新規追加'
         fill_in 'article_title', with: '111111111122222222223333333333444444444455555555556'
-        click_button '作成'
+        click_button '保存'
         expect(page).to have_content 'タイトル は50文字以内で入力してください'
       end
 
@@ -77,6 +76,10 @@ describe 'Articles', js: true, type: :system do
 
     context 'when normal employee is logged in' do
       let(:login_employee) { normal_employee }
+
+      before do
+        FactoryBot.create(:article, title: '検索機能', created_at: '2022/10/31', employee: manager_employee)
+      end
 
       it 'article index appear' do
         click_link 'お知らせ'

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -50,6 +50,22 @@ describe 'Articles', js: true, type: :system do
         expect(page).to have_content '「MyNumber」を作成しました。'
       end
 
+      it 'appear validation title' do
+        click_link 'お知らせ'
+        click_link '新規追加'
+        fill_in 'article_title', with: ''
+        click_button '作成'
+        expect(page).to have_content 'タイトル を入力してください'
+      end
+
+      it 'appear validation title length' do
+        click_link 'お知らせ'
+        click_link '新規追加'
+        fill_in 'article_title', with: '111111111122222222223333333333444444444455555555556'
+        click_button '作成'
+        expect(page).to have_content 'タイトル は50文字以内で入力してください'
+      end
+
       it 'delete article' do
         click_link 'お知らせ'
         click_link '削除'

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -49,6 +49,13 @@ describe 'Articles', js: true, type: :system do
         click_button '作成'
         expect(page).to have_content 'MyNumberを作成しました。'
       end
+
+      it 'delete article' do
+        click_link 'お知らせ'
+        click_link '削除'
+        page.driver.browser.switch_to.alert.accept
+        expect(page).to have_content '「MyString」を削除しました。'
+      end
     end
 
     context 'when normal employee is logged in' do


### PR DESCRIPTION
## 実装する内容
### 一覧
- [x] メニューのお知らせをクリックしたとき、お知らせの一覧画面に遷移する。
  - [x] 一覧には、タイトル、公開日を表示する。
  - [x] 公開日でソート（昇順／降順）ができる。デフォルトは公開日の降順で表示する。
  - [x] ソートの条件を切り替えることができる
- [x] ログインユーザがお知らせ投稿権限を持っている場合、新規追加ボタン／編集ボタン／削除ボタンを表示する。
  - [x] お知らせの記事は自分が投稿した記事のみ編集／削除ができる。
- [x] 新規登録ボタンをクリックしたとき、お知らせ登録画面に遷移する。
- [x] 編集ボタンをクリックしたとき、お知らせ登録画面に遷移する。
- [x] 削除ボタンをクリックしたとき、削除の確認ダイアログを表示して、お知らせの削除ができる。
- [x] タイトルをクリックしたとき、お知らせ参照画面に遷移する。

### お知らせ登録
- [x] お知らせの登録ができる。
- [x] 保存ボタンをクリックしたとき、バリデーションチェックを行う。
  - [x] タイトル：入力されているか？ ： "タイトルが入力されていません"
  - [x] タイトル：50文字以内か？ ： "タイトルは50文字以内で入力してください"
- [x] 登録した後、一覧画面に遷移する。

### お知らせ参照
- [x] お知らせの記事を表示する。
- [x] 一覧に戻るボタンをクリックしたときに、一覧画面へ遷移する。

## UI
### お知らせ一覧
#### 権限のあるユーザーと権限のないユーザー
<img width="996" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/197370077-3efb0139-866d-4969-914a-19299a7c1142.png">

<img width="814" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/197370132-ae477991-5f37-41b6-9036-a7f286389e67.png">

#### ソートの切り替え
[![Image from Gyazo](https://i.gyazo.com/ab8bac3af07407b362e6b82d7b98eead.gif)](https://gyazo.com/ab8bac3af07407b362e6b82d7b98eead)

#### お知らせを削除する
[![Image from Gyazo](https://i.gyazo.com/f916f4b78d3fa72faf7cad64c2e3dded.gif)](https://gyazo.com/f916f4b78d3fa72faf7cad64c2e3dded)

### お知らせ登録
#### バリデーションの表示
[![Image from Gyazo](https://i.gyazo.com/e2af9b2e009293fda0bedf37c5bad37f.gif)](https://gyazo.com/e2af9b2e009293fda0bedf37c5bad37f)

### 登録後のページ遷移
[![Image from Gyazo](https://i.gyazo.com/66a24191e7472059d27379f0af6d3305.gif)](https://gyazo.com/66a24191e7472059d27379f0af6d3305)

### お知らせ参照

<img width="822" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/197370449-d36bcc9e-a4e8-48b7-b75f-faa3bf20f5af.png">

[![Image from Gyazo](https://i.gyazo.com/ae933db1dfd0573b29882cfcafc7df6d.gif)](https://gyazo.com/ae933db1dfd0573b29882cfcafc7df6d)