### PR TITLE
全体的なレイアウトを修正

### DIFF
--- a/app/assets/stylesheets/employees.scss
+++ b/app/assets/stylesheets/employees.scss
@@ -4,11 +4,6 @@
     margin-right: 31px;
   }
 
-  .btn {
-    border: 1px solid;
-    padding: 3px 5px;
-  }
-
   .employee_table {
     height: fit-content;
     width: 700px;
@@ -53,7 +48,8 @@
     }
 
     input {
-      width: 150px;
+      width: 16rem;
+      height: 2.4rem;
       margin-right: 20px;
       margin-top: 5px;
     }
@@ -80,8 +76,5 @@
     position: absolute;
     top: -38px;
     right: 20px;
-    padding: 0px 22px;
-    background-color: white;
-    border: 1px solid;
   }
 }

--- a/app/assets/stylesheets/profiles.scss
+++ b/app/assets/stylesheets/profiles.scss
@@ -1,15 +1,11 @@
 .profile_space {
   position: relative;
   margin-top: 30px;
+  width: 80%;
 
   .employee_index {
     text-align: right;
     margin-right: 10px;
-  }
-
-  .btn {
-    border: 1px solid;
-    padding: 3px 5px;
   }
 
   .label {
@@ -46,7 +42,5 @@
     top: -19px;
     right: 0px;
     padding: 0px 22px;
-    background-color: white;
-    border: 1px solid;
   }
 }

--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -22,11 +22,11 @@
 
 input[type="text"] {
   width: 300px;
-  height: 22px;
+  height: 32px;
 }
 
 input[type="password"] {
   width: 300px;
-  height: 22px;
+  height: 32px;
 }
 

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -12,6 +12,7 @@ class Employee < ApplicationRecord
   validates :first_name, presence: true
   validates :account, presence: true, uniqueness: true
   validates :password, presence: true
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, message: 'に使える文字のみ入力してください' }
 
   scope :active, lambda {
     where(deleted_at: nil)

--- a/app/views/employees/_form.html.slim
+++ b/app/views/employees/_form.html.slim
@@ -1,40 +1,43 @@
 .employee_form
   - if employee.errors.present?
-    ul
+    ul.error-message.text-danger.ps-0
       - employee.errors.full_messages.each do |message|
-        li
+        li.alert-success
           = message
   = form_with model: employee, local: true do |f|
-    .form_group
+    .form_group.my-2
       = f.label :number
-      = f.text_field :number
-    .form_group
+      = f.text_field :number, class: 'form-control mt-1 new-employee-form'
+    .form_group.mb-2
       = f.label :last_name
-      = f.text_field :last_name
+      = f.text_field :last_name, class: 'form-control mt-1 new-employee-form'
+    .form_group.mb-2
       = f.label :first_name
-      = f.text_field :first_name
-    .form_group
+      = f.text_field :first_name, class: 'form-control mt-1 new-employee-form'
+    .form_group.mb-2
       = f.label :account
-      = f.text_field :account
-    .form_group
+      = f.text_field :account, class: 'form-control mt-1 new-employee-form'
+    .form_group.mb-2
       = f.label :password
-      = f.password_field :password
-    .form_group
+      = f.password_field :password, placeholder: 'password', class: 'form-control mt-1 new-employee-form'
+    .form_group.mb-2
       = f.label :e_mail
-      = f.text_field :email
-    .form_group
+      = f.text_field :email, placeholder: 'sample@example.com', class: 'form-control mt-1 new-employee-form'
+    .form_group.mb-2
       = f.label :date_of_joining
-      = f.text_field :date_of_joining
-    .form_group
+      = f.text_field :date_of_joining, placeholder: 'YYYY/MM/DD', class: 'form-control mt-1 new-employee-form'
+    .form_group.mb-2
       = f.label :department_id
       = f.collection_select(:department_id, @departments, :id, :name)
-    .form_group
+    .form_group.mb-2
       = f.label :office_id
       = f.collection_select(:office_id, @offices, :id, :name)
-    .form_group
-      = f.label :employee_info_manage_auth, class: 'checkbox_label'
-      = f.check_box :employee_info_manage_auth, { as: :boolean }
-    .form_group
-      = f.label :news_posting_auth, class: 'checkbox_label'
-      = f.check_box :news_posting_auth, { as: :boolean }
-    = f.submit '保存'
+    .form_check.mb-2
+      = f.check_box :employee_info_manage_auth, { as: :boolean }, class: 'form-check-input'
+      = f.label :employee_info_manage_auth, class: 'form-check-label ms-3'
+    .form_check.mb-2
+      = f.check_box :news_posting_auth, { as: :boolean }, class: 'form-check-input'
+      = f.label :news_posting_auth, class: 'form-check-label ms-3'
+    = f.submit nil, class: 'btn btn-primary mb-2'
+    .nav.justify-content-end.my-3
+      = link_to '一覧に戻る', employees_path, class: 'btn btn-secondary'

--- a/app/views/employees/index.html.slim
+++ b/app/views/employees/index.html.slim
@@ -1,11 +1,11 @@
 .employee_index
   - if flash.notice.present?
-    p
+    .alert.alert-success.mt-1
       = flash.notice
   - if current_user.employee_info_manage_auth
-    p.new_employee
-      = link_to '新規追加', new_employee_path, class: 'btn'
-  table.employee_table
+    .nav.justify-content-end.mt-2
+      = link_to '新規追加', new_employee_path, class: 'btn btn-primary'
+  table.employee_table.text-center
     thead
       tr
         th
@@ -27,15 +27,15 @@
           - else
             th
               = link_to employee.number, employee_profiles_path(employee)
-        th.name
-          = "#{employee.last_name} #{employee.first_name}"
-        th
-          = employee.department.name
-        - if current_user.employee_info_manage_auth
-          th.btn_th
-            = link_to '編集', edit_employee_path(employee), class: 'btn'
-          th.btn_th
-            = link_to '削除', employee, method: :delete, data: { confirm: "社員「#{employee.first_name} #{employee.last_name}」を削除します。よろしいですか？" }, class: 'btn'
+            th.name
+              = "#{employee.last_name} #{employee.first_name}"
+            th
+              = employee.department.name
+            - if current_user.employee_info_manage_auth
+              th.btn_th.my-2
+                = link_to '編集', edit_employee_path(employee), class: 'btn btn-secondary'
+              th.btn_th.my-2.ms-2
+                = link_to '削除', employee, method: :delete, data: { confirm: "社員「#{employee.first_name} #{employee.last_name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'
   .kaminari.mt-3
     = paginate @employees, theme: 'bootstrap-5'
     = page_entries_info @employees

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,17 +1,17 @@
 = javascript_pack_tag 'header.js'
 #menu
-  ul.left_menu
+  ul.left_menu.my-auto.p-2
     li
       = link_to 'お知らせ', articles_path
     li
       = link_to '社員紹介', employees_path
-  ul.right_menu
+  ul.right_menu.my-auto.p-2
     li
       button#dropdown__btn.dropdown__btn
         = "#{@current_user.last_name} #{@current_user.first_name}"
 #dropdown_menu
   .right_menu
-    .dropdown_items
-      ul
+    .dropdown_items.mt-2
+      ul.my-auto
         li
           = link_to 'ログアウト', logout_path, method: :delete

--- a/app/views/profiles/_employee_info.html.slim
+++ b/app/views/profiles/_employee_info.html.slim
@@ -1,15 +1,12 @@
-.row
-  span.label
-    | 社員番号
-  span
-    = employee.number
-.row
-  span.label
-    | 氏名
-  span
-    = "#{employee.last_name} #{employee.first_name}"
-.row
-  span.label
-    | 部署
-  span
-    = employee.department.name
+.form-labrl.justify-content-start
+  | 社員番号
+.form-control.mb-2
+  = @employee.number
+.form-labrl.justify-content-start
+  | 氏名
+.form-control.mb-2
+  = "#{employee.last_name} #{employee.first_name}"
+.form-labrl.justify-content-start
+  | 部署
+.form-control.mb-2
+  = employee.department.name

--- a/app/views/profiles/_form.html.slim
+++ b/app/views/profiles/_form.html.slim
@@ -1,11 +1,13 @@
 - if profile.errors.present?
-  ul
+  ul.error-message.text-danger.ps-0
     - profile.errors.full_messages.each do |message|
-      li
+      li.alert-success
         = message
 = render partial: 'employee_info', locals: { employee: @employee }
 = form_with model: [employee, profile], local: true do |f|
-  .form_group
-    = f.label :profile, class: 'label'
-    = f.text_area :profile
-  = f.submit '保存'
+  .mb-3
+    = f.label :profile, class: 'form-label'
+    = f.text_area :profile, class: 'form-control mt-1 new-article-form text-area-size'
+  = f.submit nil, class: 'btn btn-primary'
+.nav.justify-content-end.my-3
+  = link_to '一覧に戻る', employees_path, class: 'btn btn-secondary'

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -1,9 +1,8 @@
 .profile_space
-  p.employee_index
-    = link_to '一覧に戻る', employees_path, class: 'btn'
+  .nav.justify-content-end
+    = link_to '一覧に戻る', employees_path, class: 'btn btn-primary'
   = render partial: 'employee_info', locals: { employee: @employee }
-  .row
-    span.label
-      | プロフィール
-    span.profile_value
-      = @profile.profile
+  .form-labrl.justify-content-start
+    | プロフィール
+  .form-control
+    = @profile.profile

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -8,8 +8,8 @@
       = f.password_field :password, class: 'form-control'
     - if flash[:alert]
       .form-group
-        p
+        p.text-danger
           = flash[:alert]
     .row-center
       p
-        = f.submit 'ログイン', class: 'form-submit'
+        = f.submit 'ログイン', class: 'form-submit btn btn-primary'

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Employee, type: :model do
       last_name: 'aoi',
       first_name: 'tsukada',
       account: 'tsukada',
-      password: 'password'
+      password: 'password',
+      email: 'sample@example.com'
     )
     expect(employee).to be_valid
   end

--- a/spec/system/employees_spec.rb
+++ b/spec/system/employees_spec.rb
@@ -32,20 +32,20 @@ describe 'Employees', js: true, type: :system do
       end
 
       it 'delete employee' do
-        all('tbody tr')[1].click_link '削除'
+        all('tbody th')[4].click_link '削除'
         page.driver.browser.switch_to.alert.accept
         expect(page).to have_content "「#{manager_employee.last_name} #{manager_employee.first_name}」を削除しました"
       end
 
       it 'edit employee' do
-        all('tbody tr')[1].click_link '編集'
+        all('tbody th')[3].click_link '編集'
         fill_in 'employee_last_name', with: '治'
         fill_in 'employee_first_name', with: '太宰'
         fill_in 'employee_password', with: manager_employee.password
         select '技術部', from: 'employee_department_id'
         select '大阪', from: 'employee_office_id'
-        click_on '保存'
-        all('tbody tr')[1].click_link '編集'
+        click_button '更新'
+        all('tbody th')[3].click_link '編集'
         expect(page).to have_content '治 太宰'
         expect(page).to have_content '技術部'
         expect(page).to have_content '大阪'


### PR DESCRIPTION
## 目的
お知らせ以外のレイアウトを修正すること

## 実施したこと
- Employee登録をするときにメールアドレスのバリデーションチェックが行われる
- Employee関連のレイアウトを修正
- Profile関連のレイアウトを修正
- ログイン画面のレイアウトを修正

## UI
### Employee一覧
#### before
<img width="1435" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/197425894-c92b30f9-b37d-41b5-a43b-ba8a45f64a8f.png">


#### after
<img width="1214" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/197425598-7a0c3f72-afa5-41e5-86ca-0c33ae3573c4.png">

### Employee新規登録
#### before
<img width="660" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/197425667-8bfa8d98-d87f-45af-9dd0-f8a49e6faf68.png">

#### after
<img width="398" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/197425642-e83b6d54-558e-423f-b537-902bd1c25689.png">

<img width="459" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/197425655-154d82cd-b715-44c0-8926-80bdd3998481.png">

### Employee詳細
#### before
<img width="723" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/197425991-69c67e43-6116-4e5d-baf8-0106066ffc69.png">

#### after

<img width="808" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/197425949-7c4dae3e-6549-4925-9e91-396c03bb0d50.png">

<img width="827" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/197425965-7c90e738-384b-4a9c-9eed-c16b7e5780cd.png">

### ログイン画面

#### before
<img width="341" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/197426184-b9817562-c185-4952-b7f4-3285b56c12ff.png">

#### after
<img width="312" alt="NewsAndEmployeeIntroduction" src="https://user-images.githubusercontent.com/62058863/197426188-c284f29d-5309-41f5-9acf-1c6f592618f9.png">
