### PR TITLE
CSSを修正する

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -109,19 +109,6 @@ tr {
   border: 0;
 }
 
-.article {
-  width: 80%;
-}
-
-.form-group .new-article-form {
-  width: 100%;
-}
-
-.text-area-size {
-  height: 16rem;
-}
-
-
 .alert.alert-success {
   height: 3.2rem;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -110,7 +110,7 @@ tr {
 }
 
 .alert.alert-success {
-  height: 3.2rem;
+  height: 51.2px;
 }
 
 ul.error-message {

--- a/app/assets/stylesheets/article.scss
+++ b/app/assets/stylesheets/article.scss
@@ -1,0 +1,11 @@
+.article {
+  width: 80%;
+}
+
+.form-group .new-article-form {
+  width: 100%;
+}
+
+.text-area-size {
+  height: 256px;
+}

--- a/app/assets/stylesheets/employees.scss
+++ b/app/assets/stylesheets/employees.scss
@@ -48,8 +48,8 @@
     }
 
     input {
-      width: 16rem;
-      height: 2.4rem;
+      width: 256px;
+      height: 38.4px;
       margin-right: 20px;
       margin-top: 5px;
     }

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -3,7 +3,7 @@
 # rubocop:disable Rails/UniqueValidationWithoutIndex
 class Employee < ApplicationRecord
   def self.csv_attributes
-    %w[department_id office_id number last_name first_name account email date_of_joining ]
+    %w[department_id office_id number last_name first_name account email date_of_joining]
   end
 
   def self.generate_csv


### PR DESCRIPTION
## 目的
cssの書き方を統一する
  - 既存のコードに合わせた書き方ができていなかったため修正した

## 実施したこと
- cssファイルの整理
- cssの単位をpxに統一