### PR TITLE
rubocop-rspecの設定を追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rspec
+
 inherit_gem:
   rubocop-fjord:
     - config/rubocop.yml
@@ -10,6 +12,12 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Exclude:
     - spec/**/*
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Max: 15
 
 AllCops:
   Exclude:

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -63,49 +63,49 @@ RSpec.describe Employee, type: :model do
   end
 
   it 'checks csv columns department' do
-    csv_content = Employee.generate_csv
+    csv_content = described_class.generate_csv
     csv = CSV.parse(csv_content)
     expect(csv[0][0]).to eq 'department_id'
   end
 
   it 'checks csv columns office' do
-    csv_content = Employee.generate_csv
+    csv_content = described_class.generate_csv
     csv = CSV.parse(csv_content)
     expect(csv[0][1]).to eq 'office_id'
   end
 
   it 'checks csv columns number' do
-    csv_content = Employee.generate_csv
+    csv_content = described_class.generate_csv
     csv = CSV.parse(csv_content)
     expect(csv[0][2]).to eq 'number'
   end
 
   it 'checks csv columns last_name' do
-    csv_content = Employee.generate_csv
+    csv_content = described_class.generate_csv
     csv = CSV.parse(csv_content)
     expect(csv[0][3]).to eq 'last_name'
   end
 
   it 'checks csv columns first_name' do
-    csv_content = Employee.generate_csv
+    csv_content = described_class.generate_csv
     csv = CSV.parse(csv_content)
     expect(csv[0][4]).to eq 'first_name'
   end
 
   it 'checks csv columns account' do
-    csv_content = Employee.generate_csv
+    csv_content = described_class.generate_csv
     csv = CSV.parse(csv_content)
     expect(csv[0][5]).to eq 'account'
   end
 
   it 'checks csv columns email' do
-    csv_content = Employee.generate_csv
+    csv_content = described_class.generate_csv
     csv = CSV.parse(csv_content)
     expect(csv[0][6]).to eq 'email'
   end
 
   it 'checks csv columns date_of_joining' do
-    csv_content = Employee.generate_csv
+    csv_content = described_class.generate_csv
     csv = CSV.parse(csv_content)
     expect(csv[0][7]).to eq 'date_of_joining'
   end


### PR DESCRIPTION
## 目的
rubocop-rspecの設定を`rubocop.yml`に追加した。

## 実施したこと
- `rubocop.yml`にrubocop-rspecの設定を追加
- rubocopの指摘を修正